### PR TITLE
Add wireguard tooling and config

### DIFF
--- a/.chezmoiscripts/run_once_before_00-install-packages.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00-install-packages.sh.tmpl
@@ -33,7 +33,8 @@
      "docker-compose-plugin"
      "yubikey-manager" 
      "libaio"
-     "libnsl" -}}
+     "libnsl"
+     "wireguard-tools" -}}
 
 {{ $sudo := "sudo " -}}
 {{ if eq .chezmoi.username "root" -}}


### PR DESCRIPTION
I want to integrate wireguard to connect with my home.
See [here](https://fedoramagazine.org/build-a-virtual-private-network-with-wireguard/)